### PR TITLE
skip doctype as one possible fix for failure

### DIFF
--- a/lib/HTML/Parser/XML.pm6
+++ b/lib/HTML/Parser/XML.pm6
@@ -72,7 +72,6 @@ class HTML::Parser::XML {
           self!ds if $cbuffer !~~ m{ [ '>' | '/' ] };
           $cbuffer = $.html.substr($.index, 1);
           $qnest = 0;
-          say :$tag.perl;
           if $tag eq '!--' {
             while $.html.substr($.index, 3) ne '-->' {
               $buffer ~= $.html.substr($.index,1);


### PR DESCRIPTION
==> Testing HTML::Parser::XML
t/01_basic.t ........ Invocant requires a type object, but an object instance was passed
  in method ACCEPTS at src/gen/m-CORE.setting:865
  in block  at lib/HTML/Parser/XML.pm6:85
  in block  at lib/HTML/Parser/XML.pm6:80
  in method parse at lib/HTML/Parser/XML.pm6:55
  in block <unit> at t/01_basic.t:9
