### PR TITLE
Fix a bug with shitty html where the wrong tag receive a / ending 

### DIFF
--- a/lib/HTML/Parser/XML.pm6
+++ b/lib/HTML/Parser/XML.pm6
@@ -91,7 +91,7 @@ class HTML::Parser::XML {
               $qnest   = 0        if $cbuffer eq $mquote && $qnest == 1;
             }
             $.index++;
-            { $aclose = 1; ++$.index; $cbuffer = $.html.substr($.index, 1); } if $cbuffer eq '/';
+            { $aclose = 1 if %!voids{$tag}.defined; ++$.index; $cbuffer = $.html.substr($.index, 1); } if $cbuffer eq '/';
           }
           #parse attribute string;
           $bindex  = 0;

--- a/t/08_dubious.t
+++ b/t/08_dubious.t
@@ -1,0 +1,28 @@
+use lib 'lib';
+use HTML::Parser::XML;
+use Test;
+
+my $parser = HTML::Parser::XML.new;
+
+my $data = slurp 't/data/dubious.html';
+
+$parser.parse($data);
+
+my $xmldoc = $parser.xmldoc;
+
+plan 5;
+
+my $divpony = $xmldoc.root.elements(:TAG<div>, :class<ponies>, :RECURSE<3>)[0];
+
+#say "div pony" , $(@divpony);
+
+ok $divpony.elements.elems eq 3, "Found the 3 elements in the ponies div";
+
+ok $divpony.elements(:TAG<img>, :class<unicorn>, :RECURSE<5>, :SINGLE), "Found the unicorn image";
+ok $divpony.elements(:TAG<img>, :class<pegasus>, :RECURSE<5>, :SINGLE), "Found the pegasus image";
+
+my $unicorn_img = $divpony.elements(:TAG<img>, :class<unicorn>, :RECURSE<5>)[0];
+my $pegasus_img = $divpony.elements(:TAG<img>, :class<pegasus>, :RECURSE<5>)[0];
+
+ok $unicorn_img.attribs<src> eq 'unicorn.png', "Right value for unicorn image";
+ok $pegasus_img.attribs<src> eq 'pegasus.png', "Right value for pegasus image";

--- a/t/data/dubious.html
+++ b/t/data/dubious.html
@@ -1,0 +1,18 @@
+<html>
+<head></head>
+<body>
+<div class="ponies">
+	<div class="unicorn">
+		<!-- i tag is bogus here -->
+		<p>I am a pretty <i />unicorn</i>: <img class="unicorn" src="unicorn.png"></p>
+	</div>
+	<div class="pegasus">
+		<!-- this img tag has the / closure -->
+		<p>I can fly because I am <i>pegasus</i>: <img class="pegasus" src="pegasus.png"/></p>
+	</div>
+	<div class="earthpony"/>
+		<p>I am pretty <span class="red">useless</span></p>
+	</div>
+<!-- Missing closing div-->
+</body>
+</html>


### PR DESCRIPTION
eg : <span/></span>

Without this fix test 1, 3 and 5 for 08_debious fail due to the module closing tag too soon and mess up the resulting xml tree.

I have no idea if this change as some side effect (all tests still pass). Basicly the change make that only empty tags (like <area> or <img>) can put a closure when a /> is met.