### PR TITLE
Fix broken UTF 8 test

### DIFF
--- a/t/04_utf.t
+++ b/t/04_utf.t
@@ -12,6 +12,7 @@ $parser.parse($html);
 
 is $parser.xmldoc.root.elements.elems, 2, 'root:elements:elems';
 is $parser.xmldoc.root.name, 'html', 'root:tag:html';
-is  $parser.xmldoc.root.elements[1].elements[0], 
-    $html.subst(/\n+/, ' ', :g) ~~ rx{ '<code>'(.*?)'</code>' }, 
-    'html:body:code:♥';
+
+is  $parser.xmldoc.root.elements[1].elements[0],
+        $html ~~ rx{ ('<code>'.*?'</code>') },
+        'html:body:code:♥';


### PR DESCRIPTION
Installation failed because the utf 8 test removed all new lines before comparing. Additional the \<code> tags were removed. I do not know if is a bug or indented, though.